### PR TITLE
Clarify what the webhook URL should be

### DIFF
--- a/find-candidates-and-retrieve-their-details/python/README.md
+++ b/find-candidates-and-retrieve-their-details/python/README.md
@@ -6,15 +6,15 @@ It is a fully working application of the example shown at https://rolepoint-conn
 
 ## How to run this example
 
-You will need a sandbox account for Connect.  [Get one here](https://rolepoint-connect.readme.io/docs/sandbox-connector).
-
 For this example to run it will need to be exposed to the internet. This is because it takes advantage of the callback functionality of Connect, so Connect needs to be able to communicate back to the example application. We recommend using [ngrok](https://ngrok.com) for this - it can expose a port on your local machine to the internet, allowing you to receive the webhooks sent from connect. For the purposes of this guide, we will assume you are using ngrok and have successfully installed it.
 
 The example will be exposed on port 5000, so we start ngrok up to expose the local server:
 
     > ngrok http 5000
 
-The output from the above command will include a line which says `Forwarding`, with a URL which looks like `https://2fb65876.ngrok.io`. Note that yours will have a different subdomain. 
+The output from the above command will include a line which says `Forwarding`, with a URL which looks like `https://2fb65876.ngrok.io`. Note that yours will have a different subdomain.
+
+Now you can get a sandbox account for Connect. [Steps to get one here](https://rolepoint-connect.readme.io/docs/sandbox-connector).
 
 You will need to edit `app.py` and change the settings on lines 27-30. 
 

--- a/get-jobs-and-insert-applications/python/README.md
+++ b/get-jobs-and-insert-applications/python/README.md
@@ -6,15 +6,15 @@ It is a fully working application of the example shown at https://rolepoint-conn
 
 ## How to run this example
 
-You will need a sandbox account for Connect. [Get one here](https://rolepoint-connect.readme.io/docs/sandbox-connector).
-
 Connect sends jobs to client applications using webhooks. For the example to receive these webhooks it will need to be exposed to the internet. We recommend using [ngrok](https://ngrok.com) for this - it can expose a port on your local machine to the internet, allowing you to receive the webhooks sent from connect. For the purposes of this guide, we will assume you are using ngrok and have successfully installed it.
 
 The example will be exposed on port 5000, so we start ngrok up to expose the local server:
 
     > ngrok http 5000
 
-The output from the above command will include a line which says `Forwarding`, with a URL which looks like `https://2fb65876.ngrok.io`. Note that yours will have a different subdomain. 
+The output from the above command will include a line which says `Forwarding`, with a URL which looks like `https://2fb65876.ngrok.io`. Note that yours will have a different subdomain.
+
+Now you can get a sandbox account for Connect, using `https://2fb65876.ngrok.io/webhook_url` as your webhook URL. [Steps to get one here](https://rolepoint-connect.readme.io/docs/sandbox-connector).
 
 You will need to edit `app.py` and change the settings on lines 27-30. 
 

--- a/insert-candidate-and-track-status/python/README.md
+++ b/insert-candidate-and-track-status/python/README.md
@@ -6,15 +6,15 @@ It is a fully working application of the example shown at https://rolepoint-conn
 
 ## How to run this example
 
-You will need a sandbox account for Connect.  [Get one here](https://rolepoint-connect.readme.io/docs/sandbox-connector).
-
 Connect sends candidate status updates to client applications using webhooks. For the example to receive these webhooks it will need to be exposed to the internet. We recommend using [ngrok](https://ngrok.com) for this - it can expose a port on your local machine to the internet, allowing you to receive the webhooks sent from connect. For the purposes of this guide, we will assume you are using ngrok and have successfully installed it.
 
 The example will be exposed on port 5000, so we start ngrok up to expose the local server:
 
     > ngrok http 5000
 
-The output from the above command will include a line which says `Forwarding`, with a URL which looks like `https://2fb65876.ngrok.io`. Note that yours will have a different subdomain. 
+The output from the above command will include a line which says `Forwarding`, with a URL which looks like `https://2fb65876.ngrok.io`. Note that yours will have a different subdomain.
+
+Now you can get a sandbox account for Connect, using `https://2fb65876.ngrok.io/webhook_url` as your webhook URL. [Steps to get one here](https://rolepoint-connect.readme.io/docs/sandbox-connector).
 
 You will need to edit `app.py` and change the settings on lines 27-30.
 


### PR DESCRIPTION
While going through the steps to set up the examples, I went to the link to get a sandbox account, saw that I needed a webhook url, continued with the steps until I had the url from `ngrok` and then finished getting the sandbox account.

I think that if we avoid this going back and forth, the users experience following the steps will be better.

Opinions?